### PR TITLE
Add mbed_nano to list of compatible architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=A library for DS18B20 temperature sensor and Arduino NANO 33 BLE contro
 paragraph=It implements 1-Wire MaximIntegrated bus protocol
 category=Sensors
 url=https://github.com/adameat/MaximWire
-architectures=nordicnrf52,mbed
+architectures=nordicnrf52,mbed,mbed_nano
 includes=MaximWire.h


### PR DESCRIPTION
In the 2.0.0 release of the Arduino Mbed OS Boards platform, the mbed architecture split into four architectures:

- mbed_edge: Arduino Edge Control
- mbed_nano: Nano 33 BLE and Nano RP2040 Connect
- mbed_rp2040: Raspberry Pi Pico
- mbed_portenta: Portenta H7

The mbed architecture should be retained for backwards support, but the new mbed_nano should also be added to avoid spurious incompatibility warnings and the library's examples being shown under the File > Examples > INCOMPATIBLE menu of the Arduino IDE when the Nano 33 BLE board is selected.